### PR TITLE
[UPDATE] 4.0 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+settings.json
 bin
 deploy.sh
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ Select it and click `Install Add-on`.
 <details open><summary><b>v4.0.0</b></summary><br>
 Compatibility update for Blender 4.0
 
+- `ADDED` : support for Blender 4.0
+  - `ADDED` : auto-save/load preferences
 - `UPDATED` : replace bgl module refs with gpu module implementation
 - `UPDATED` : Swap Control Regions fixed context override implementation
 - `UPDATED` : early exit when dragging gizmo near edge of viewport to prevent negative overflow

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Select it and click `Install Add-on`.
 # Changelog
 
 <details open><summary><b>v4.0.0</b></summary><br>
-Compatbility update for Blender 4.0
+Compatibility update for Blender 4.0
 
 - `UPDATED` : replace bgl module refs with gpu module implementation
 - `UPDATED` : Swap Control Regions fixed context override implementation

--- a/README.md
+++ b/README.md
@@ -183,6 +183,16 @@ Select it and click `Install Add-on`.
 
 # Changelog
 
+<details open><summary><b>v4.0.0</b></summary><br>
+Compatbility update for Blender 4.0
+
+- `UPDATED` : replace bgl module refs with gpu module implementation
+- `UPDATED` : Swap Control Regions fixed context override implementation
+- `UPDATED` : early exit when dragging gizmo near edge of viewport to prevent negative overflow
+- `REMOVED` : argument renaming to disregard unused args (currently breaking CI/CD)
+
+</details>
+
 <details open><summary><b>v2.12.0</b></summary><br>
 
 - `UPDATED` : fixed bug with unindexed modes breaking gizmo menus

--- a/Settings.py
+++ b/Settings.py
@@ -1,4 +1,6 @@
 # type: ignore
+import json
+from os import path
 from bpy.props import (BoolProperty, CollectionProperty, EnumProperty,
                        FloatProperty, FloatVectorProperty, IntProperty,
                        StringProperty)
@@ -22,6 +24,30 @@ class MenuModeGroup(PropertyGroup):
     menu_slot_6: StringProperty(name='Menu Item', default='')
     menu_slot_7: StringProperty(name='Menu Item', default='')
     menu_slot_8: StringProperty(name='Menu Item', default='')
+
+    def to_dict(self):
+        return {
+            "mode": self.mode,
+            "menu_slot_1": self.menu_slot_1,
+            "menu_slot_2": self.menu_slot_2,
+            "menu_slot_3": self.menu_slot_3,
+            "menu_slot_4": self.menu_slot_4,
+            "menu_slot_5": self.menu_slot_5,
+            "menu_slot_6": self.menu_slot_6,
+            "menu_slot_7": self.menu_slot_7,
+            "menu_slot_8": self.menu_slot_8
+        }
+
+    def from_dict(self, data: dict):
+        self.mode = data.get('mode', 'OBJECT')
+        self.menu_slot_1 = data.get('menu_slot_1', '')
+        self.menu_slot_2 = data.get('menu_slot_2', '')
+        self.menu_slot_3 = data.get('menu_slot_3', '')
+        self.menu_slot_4 = data.get('menu_slot_4', '')
+        self.menu_slot_5 = data.get('menu_slot_5', '')
+        self.menu_slot_6 = data.get('menu_slot_6', '')
+        self.menu_slot_7 = data.get('menu_slot_7', '')
+        self.menu_slot_8 = data.get('menu_slot_8', '')
 
 
 class OverlaySettings(AddonPreferences):
@@ -221,6 +247,131 @@ class OverlaySettings(AddonPreferences):
         ('MENU', 'Gizmo Menu', '', 0),
         ('ACTIONS', 'Action Menu', '', 1)
     ], default='MENU')
+
+    def to_dict(self):
+        return {
+            "is_enabled": self.is_enabled,
+            "lazy_mode": self.lazy_mode,
+            "toggle_position": list(self.toggle_position),
+            "toggle_color": list(self.toggle_color),
+            "is_visible": self.isVisible,
+            "input_mode": self.input_mode,
+            "enable_double_click": self.enable_double_click,
+            "double_click_mode": self.double_click_mode,
+            "enable_right_click": self.enable_right_click,
+            "right_click_mode": self.right_click_mode,
+            "right_click_source": self.right_click_source,
+            "swap_panrotate": self.swap_panrotate,
+            "width": self.width,
+            "radius": self.radius,
+            "use_multiple_colors": self.use_multiple_colors,
+            "overlay_main_color": list(self.overlay_main_color),
+            "overlay_secondary_color": list(self.overlay_secondary_color),
+            "show_menu": self.show_menu,
+            "show_gizmos": self.show_gizmos,
+            "menu_style": self.menu_style,
+            "menu_orientation": self.menu_orientation,
+            "menu_spacing": self.menu_spacing,
+            "gizmo_padding": self.gizmo_padding,
+            "gizmo_scale": self.gizmo_scale,
+            "menu_position": list(self.menu_position),
+            "show_undoredo": self.show_undoredo,
+            "show_is_enabled": self.show_is_enabled,
+            "show_control_gizmo": self.show_control_gizmo,
+            "show_show_fullscreen": self.show_show_fullscreen,
+            "show_region_quadviews": self.show_region_quadviews,
+            "show_pivot_mode": self.show_pivot_mode,
+            "show_snap_view": self.show_snap_view,
+            "show_n_panel": self.show_n_panel,
+            "show_lock_rotation": self.show_lock_rotation,
+            "show_multires": self.show_multires,
+            "show_voxel_remesh": self.show_voxel_remesh,
+            "show_brush_dynamics": self.show_brush_dynamics,
+            "gizmo_position": self.gizmo_position,
+            "subdivision_limit": self.subdivision_limit,
+            "pivot_mode": self.pivot_mode,
+            "topology_mode": self.topology_mode,
+            "show_float_menu": self.show_float_menu,
+            "floating_position": list(self.floating_position),
+            "double_click_mode": self.double_click_mode,
+            "active_menu": self.active_menu,
+            "gizmo_tabs": self.gizmo_tabs,
+            "menu_sets": [m.to_dict() for m in self.menu_sets]
+        }
+
+    # get addon preferences from dict, assert type for non-string values, missing keys will be set to default
+    def from_dict(self, data: dict):
+        self.is_enabled = data.get('is_enabled', True)
+        self.lazy_mode = data.get('lazy_mode', False)
+        self.toggle_position = data.get('toggle_position', (0.5, 0.5, 0.0))
+        self.toggle_color = data.get('toggle_color', (0.1, 0.1, 0.2, 0.5))
+        self.isVisible = data.get('is_visible', False)
+        self.input_mode = data.get('input_mode', 'full')
+        self.enable_double_click = data.get('enable_double_click', True)
+        self.double_click_mode = data.get('double_click_mode', 'screen.screen_full_area')
+        self.enable_right_click = data.get('enable_right_click', True)
+        self.right_click_mode = data.get('right_click_mode', 'wm.window_fullscreen_toggle')
+        self.right_click_source = data.get('right_click_source', 'mouse')
+        self.swap_panrotate = data.get('swap_panrotate', False)
+        self.width = data.get('width', 40.0)
+        self.radius = data.get('radius', 35.0)
+        self.use_multiple_colors = data.get('use_multiple_colors', False)
+        self.overlay_main_color = data.get('overlay_main_color', (1.0, 1.0, 1.0, 0.01))
+        self.overlay_secondary_color = data.get('overlay_secondary_color', (1.0, 1.0, 1.0, 0.01))
+        self.show_menu = data.get('show_menu', True)
+        self.show_gizmos = data.get('show_gizmos', True)
+        self.menu_style = data.get('menu_style', 'float.radial')
+        self.menu_orientation = data.get('menu_orientation', 'HORIZONTAL')
+        self.menu_spacing = data.get('menu_spacing', 20.0)
+        self.gizmo_padding = data.get('gizmo_padding', 10)
+        self.gizmo_scale = data.get('gizmo_scale', 4.0)
+        self.menu_position = data.get('menu_position', (95.00, 5.00))
+        self.show_undoredo = data.get('show_undoredo', True)
+        self.show_is_enabled = data.get('show_is_enabled', True)
+        self.show_control_gizmo = data.get('show_control_gizmo', True)
+        self.show_show_fullscreen = data.get('show_show_fullscreen', True)
+        self.show_region_quadviews = data.get('show_region_quadviews', True)
+        self.show_pivot_mode = data.get('show_pivot_mode', True)
+        self.show_snap_view = data.get('show_snap_view', True)
+        self.show_n_panel = data.get('show_n_panel', True)
+        self.show_lock_rotation = data.get('show_lock_rotation', True)
+        self.show_multires = data.get('show_multires', True)
+        self.show_voxel_remesh = data.get('show_voxel_remesh', True)
+        self.show_brush_dynamics = data.get('show_brush_dynamics', True)
+        self.gizmo_position = data.get('gizmo_position', 'RIGHT')
+        self.subdivision_limit = data.get('subdivision_limit', 4)
+        self.pivot_mode = data.get('pivot_mode', 'SURFACE')
+        self.topology_mode = data.get('topology_mode', 'MANUAL')
+        self.show_float_menu = data.get('show_float_menu', False)
+        self.floating_position = data.get('floating_position', (95.00, 5.00))
+        self.double_click_mode = data.get('double_click_mode', 'wm.window_fullscreen_toggle')
+        self.active_menu = data.get('active_menu', 'VIEW3D')
+        self.gizmo_tabs = data.get('gizmo_tabs', 'MENU')
+        self.menu_sets = [MenuModeGroup().from_dict(m) for m in data.get('menu_sets', [])]
+
+    def load(self):
+        # read addon preferences from json file
+        # if file does not exist, return
+        # if file exists, load data into addon preferences
+        filename = path.abspath(path.dirname(__file__) + '/settings.json')
+        if not path.exists(filename):
+            return None
+
+        data = {}
+        try:
+            with open(filename, 'r') as file:
+                data = json.load(file)
+                self.from_dict(data)
+        except:
+            return None
+
+    def save(self):
+        # write addon preferences to json file
+        # if file does not exist, create it
+        # if file exists, overwrite it
+        filename = path.abspath(path.dirname(__file__) + '/settings.json')
+        with open(filename, 'w') as file:
+            json.dump(self.to_dict(), file)
 
     # set up addon preferences UI
     def draw(self, _: Context):

--- a/Settings.py
+++ b/Settings.py
@@ -1,6 +1,7 @@
 # type: ignore
 import json
 from os import path
+
 from bpy.props import (BoolProperty, CollectionProperty, EnumProperty,
                        FloatProperty, FloatVectorProperty, IntProperty,
                        StringProperty)

--- a/Settings.py
+++ b/Settings.py
@@ -299,7 +299,6 @@ class OverlaySettings(AddonPreferences):
             "menu_sets": [m.to_dict() for m in self.menu_sets]
         }
 
-    # get addon preferences from dict, assert type for non-string values, missing keys will be set to default
     def from_dict(self, data: dict):
         self.is_enabled = data.get('is_enabled', True)
         self.lazy_mode = data.get('lazy_mode', False)
@@ -350,9 +349,6 @@ class OverlaySettings(AddonPreferences):
         self.menu_sets = [MenuModeGroup().from_dict(m) for m in data.get('menu_sets', [])]
 
     def load(self):
-        # read addon preferences from json file
-        # if file does not exist, return
-        # if file exists, load data into addon preferences
         filename = path.abspath(path.dirname(__file__) + '/settings.json')
         if not path.exists(filename):
             return None
@@ -366,9 +362,6 @@ class OverlaySettings(AddonPreferences):
             return None
 
     def save(self):
-        # write addon preferences to json file
-        # if file does not exist, create it
-        # if file exists, overwrite it
         filename = path.abspath(path.dirname(__file__) + '/settings.json')
         with open(filename, 'w') as file:
             json.dump(self.to_dict(), file)

--- a/__init__.py
+++ b/__init__.py
@@ -36,13 +36,16 @@ bl_info = {
 }
 
 
+has_run = False
 def register():
     bpy.utils.register_class(MenuModeGroup)
     bpy.utils.register_class(OverlaySettings)
+    bpy.context.preferences.addons[__package__.split('.')[0]].preferences.load()
     lib.register()
 
 
 def unregister():
     lib.unregister()
+    bpy.context.preferences.addons[__package__.split('.')[0]].preferences.save()
     bpy.utils.unregister_class(OverlaySettings)
     bpy.utils.unregister_class(MenuModeGroup)

--- a/__init__.py
+++ b/__init__.py
@@ -26,7 +26,7 @@ bl_info = {
         "Creates active touch zones over View 2D and 3D areas for"
         "easier viewport navigation with touch screens and pen tablets.",
     "author": "NENDO",
-    "version": (2, 12, 0),
+    "version": (4, 0, 0),
     "blender": (2, 93, 0),
     "location": "View3D > Tools > NENDO",
     "warning": "",

--- a/__init__.py
+++ b/__init__.py
@@ -26,7 +26,7 @@ bl_info = {
         "Creates active touch zones over View 2D and 3D areas for"
         "easier viewport navigation with touch screens and pen tablets.",
     "author": "NENDO",
-    "version": (4, 0, 0),
+    "version": (4, 0, 1),
     "blender": (2, 93, 0),
     "location": "View3D > Tools > NENDO",
     "warning": "",
@@ -40,12 +40,12 @@ has_run = False
 def register():
     bpy.utils.register_class(MenuModeGroup)
     bpy.utils.register_class(OverlaySettings)
-    bpy.context.preferences.addons[__package__.split('.')[0]].preferences.load()
+    bpy.context.preferences.addons[__package__.split('.')[0]].preferences.load() # type: ignore
     lib.register()
 
 
 def unregister():
     lib.unregister()
-    bpy.context.preferences.addons[__package__.split('.')[0]].preferences.save()
+    bpy.context.preferences.addons[__package__.split('.')[0]].preferences.save() # type: ignore
     bpy.utils.unregister_class(OverlaySettings)
     bpy.utils.unregister_class(MenuModeGroup)

--- a/lib/Overlay.py
+++ b/lib/Overlay.py
@@ -122,7 +122,7 @@ class Overlay():
         self.__drawGeometry(vertices, indices, color, 'TRIS')
 
     def __drawGeometry(self, vertices, indices, color, type):
-        shader = gpu.shader.from_builtin('3D_UNIFORM_COLOR')
+        shader = gpu.shader.from_builtin('UNIFORM_COLOR')
         batch = batch_for_shader(shader, type, {"pos": vertices}, indices=indices)
         shader.bind()
         gpu.state.blend_set('ALPHA')

--- a/lib/Overlay.py
+++ b/lib/Overlay.py
@@ -5,7 +5,7 @@ import math
 
 import bpy
 import gpu
-from bgl import GL_BLEND, glDisable, glEnable
+import bgl
 from bpy.types import Region, SpaceView3D
 from gpu_extras.batch import batch_for_shader
 from mathutils import Vector
@@ -31,7 +31,7 @@ class Overlay():
 
     def __getColors(self, type: str):
         settings = get_settings()
-        if not settings or not settings.is_enabled:
+        if not settings.is_enabled:
             return (0.0, 0.0, 0.0, 0.0)
         if type == 'main' or not settings.use_multiple_colors:
             return settings.overlay_main_color
@@ -83,15 +83,14 @@ class Overlay():
         vertices = ((a.x, a.y), (b.x, a.y), (a.x, b.y), (b.x, b.y))
         indices = ((0, 1, 2), (2, 3, 1))
 
-        shader = gpu.shader.from_builtin('2D_UNIFORM_COLOR')
+        shader = gpu.shader.from_builtin('UNIFORM_COLOR')
         batch = batch_for_shader(shader,
                                  'TRIS', {"pos": vertices},
                                  indices=indices)
-        glEnable(GL_BLEND)
         shader.bind()
+        gpu.state.blend_set('ALPHA')
         shader.uniform_float("color", color)
         batch.draw(shader)
-        glDisable(GL_BLEND)
 
     def __renderCircle(self):
         settings = get_settings()
@@ -131,12 +130,11 @@ class Overlay():
                 indices.append((0, p - 1, p))
         indices.append((0, 1, p))
 
-        shader = gpu.shader.from_builtin('2D_UNIFORM_COLOR')
+        shader = gpu.shader.from_builtin('UNIFORM_COLOR')
         batch = batch_for_shader(shader,
                                  'TRIS', {"pos": vertices},
                                  indices=indices)
-        glEnable(GL_BLEND)
         shader.bind()
+        gpu.state.blend_set('ALPHA')
         shader.uniform_float("color", color)
         batch.draw(shader)
-        glDisable(GL_BLEND)

--- a/lib/Overlay.py
+++ b/lib/Overlay.py
@@ -1,11 +1,7 @@
-# type: ignore
-# NOTE: ignoring types here due to lack of compatibility in lower-level access
-# and issues calling a class method without a proper reference to 'self'
 import math
 
 import bpy
 import gpu
-import bgl
 from bpy.types import Region, SpaceView3D
 from gpu_extras.batch import batch_for_shader
 from mathutils import Vector
@@ -31,7 +27,7 @@ class Overlay():
 
     def __getColors(self, type: str):
         settings = get_settings()
-        if not settings.is_enabled:
+        if not settings.is_enabled and not settings.lazy_mode:
             return (0.0, 0.0, 0.0, 0.0)
         if type == 'main' or not settings.use_multiple_colors:
             return settings.overlay_main_color
@@ -106,7 +102,7 @@ class Overlay():
                                                       float]):
         settings = get_settings()
         mid = self.__getMidpoint(view)
-        radius = math.dist((0, 0), mid) * (settings.getRadius() * 0.5)
+        radius = math.dist((0, 0), mid) * (settings.getRadius() * 0.5) # type: ignore
         self.__drawCircle(mid, radius, color)
 
     def __drawCircle(self, mid: Vector, radius: float, color: tuple):

--- a/lib/Overlay.py
+++ b/lib/Overlay.py
@@ -79,14 +79,7 @@ class Overlay():
         vertices = ((a.x, a.y), (b.x, a.y), (a.x, b.y), (b.x, b.y))
         indices = ((0, 1, 2), (2, 3, 1))
 
-        shader = gpu.shader.from_builtin('UNIFORM_COLOR')
-        batch = batch_for_shader(shader,
-                                 'TRIS', {"pos": vertices},
-                                 indices=indices)
-        shader.bind()
-        gpu.state.blend_set('ALPHA')
-        shader.uniform_float("color", color)
-        batch.draw(shader)
+        self.__drawGeometry(vertices, indices, color, 'TRIS')
 
     def __renderCircle(self):
         settings = get_settings()
@@ -126,10 +119,11 @@ class Overlay():
                 indices.append((0, p - 1, p))
         indices.append((0, 1, p))
 
-        shader = gpu.shader.from_builtin('UNIFORM_COLOR')
-        batch = batch_for_shader(shader,
-                                 'TRIS', {"pos": vertices},
-                                 indices=indices)
+        self.__drawGeometry(vertices, indices, color, 'TRIS')
+
+    def __drawGeometry(self, vertices, indices, color, type):
+        shader = gpu.shader.from_builtin('3D_UNIFORM_COLOR')
+        batch = batch_for_shader(shader, type, {"pos": vertices}, indices=indices)
         shader.bind()
         gpu.state.blend_set('ALPHA')
         shader.uniform_float("color", color)

--- a/lib/operators/actions.py
+++ b/lib/operators/actions.py
@@ -14,10 +14,13 @@ class VIEW3D_OT_FlipTools(Operator):
 
     def execute(self, context: Context):
         override: Context = context.copy()  # type: ignore
+        override["area"] = context.area
+        override["region"] = context.region
         for r in context.area.regions:
             if r.type == 'TOOLS':
                 override["region"] = r
-        bpy.ops.screen.region_flip(override)
+        with context.temp_override(region=override["region"]):
+            bpy.ops.screen.region_flip()
         return FINISHED
 
     @classmethod
@@ -90,7 +93,7 @@ class VIEW3D_OT_ToggleFloatingMenu(Operator):
     bl_idname = "view3d.toggle_floating_menu"
     bl_label = "Toggle Floating Menu"
 
-    def execute(self, _: Context):
+    def execute(self, context: Context):
         settings = get_settings()
         settings.show_float_menu = not settings.show_float_menu
         return FINISHED

--- a/lib/operators/actions.py
+++ b/lib/operators/actions.py
@@ -13,13 +13,13 @@ class VIEW3D_OT_FlipTools(Operator):
     bl_label = "Tools Region Swap"
 
     def execute(self, context: Context):
-        override: Context = context.copy()  # type: ignore
+        override: Context = context.copy() 
         override["area"] = context.area
         override["region"] = context.region
         for r in context.area.regions:
             if r.type == 'TOOLS':
                 override["region"] = r
-        with context.temp_override(region=override["region"]):
+        with context.temp_override(region=override["region"]): # type: ignore
             bpy.ops.screen.region_flip()
         return FINISHED
 

--- a/lib/operators/touch.py
+++ b/lib/operators/touch.py
@@ -197,6 +197,7 @@ class VIEW3D_OT_TouchInput(Operator):
         # experimental passthrough in drawing mode
         if (settings.lazy_mode
             and not settings.is_enabled
+            and event.value == PRESS
             and brush_modes.__contains__(context.mode)
             and self.mouseTarget(context, event) != context.active_object):
             return False

--- a/lib/operators/ui.py
+++ b/lib/operators/ui.py
@@ -10,7 +10,7 @@ class VIEW3D_OT_MoveFloatMenu(Operator):
     bl_idname = "nendo.move_float_menu"
     bl_label = "Relocate Gizmo Menu"
 
-    def execute(self, _: Context):
+    def execute(self, context: Context):
         settings = get_settings()
         fence = buildSafeArea()
         span = Vector((
@@ -77,7 +77,7 @@ class VIEW3D_OT_MenuController(Operator):
     bl_idname = "nendo.move_action_menu"
     bl_label = "Relocate Action Menu"
 
-    def execute(self, _: Context):
+    def execute(self, context: Context):
         settings = get_settings()
         fence = buildSafeArea()
         span = Vector((
@@ -186,7 +186,7 @@ class VIEW3D_OT_FloatController(Operator):
     bl_idname = "nendo.move_toggle_button"
     bl_label = "Relocate Toggle Button"
 
-    def execute(self, _: Context):
+    def execute(self, context: Context):
         settings = get_settings()
         fence = buildSafeArea()
         span = Vector((

--- a/lib/operators/ui.py
+++ b/lib/operators/ui.py
@@ -206,6 +206,12 @@ class VIEW3D_OT_FloatController(Operator):
 
     def modal(self, context: Context, event: Event):
         settings = get_settings()
+        if(event.mouse_region_x<0
+           or event.mouse_region_y<0
+           or event.mouse_region_x>context.area.width 
+           or event.mouse_region_y>context.area.height):
+            # mouse out of region area broken in Blender 4.x, exit early
+            return FINISHED
         if event.type == 'MOUSEMOVE' and event.value != 'RELEASE':  # Apply
             context.region.tag_redraw()
             self.x = event.mouse_region_x

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -6,7 +6,7 @@ from ..Settings import OverlaySettings
 
 def get_settings() -> OverlaySettings:
     prefs = (
-        bpy.context.preferences.addons[__package__.split('.')[0]].preferences
+        bpy.context.preferences.addons[__package__.split('.')[0]].preferences # type: ignore
     )
     if isinstance(prefs, OverlaySettings):
         return prefs
@@ -65,4 +65,4 @@ def buildSafeArea() -> tuple[Vector, Vector]:
         min.y = panel('TOOL_HEADER')[1]
     if (panel('TOOL_HEADER')[2] == 'TOP'):
         max.y -= panel('TOOL_HEADER')[1]
-    return (min, max)
+    return (min, max) 


### PR DESCRIPTION
Targeted at resolving #31 issues related to the latest Blender v4.0 release.

4.0 Fixes
---

- `bgl` module is no longer usable for drawing overlay
   - reworked overlay to use `gpu` module to draw UI
- modal auto-wrapping bug breaks gizmo dragging near edge of viewport
   - short-term solution exits modal state when a negative mouse position is reported
   - not ideal, but a proper fix needs to come from Blender, which isn't guaranteed
- Context Override no longer possible using method arguments
   - `with context.temporary_override` used to provide proper context for operator call
- `_` prefix breaking method override calls
   - updated operators to use same arguments names as class methods

Additional Bugfixes & Improvements
---

- Lazy Mode fix when using touch/mouse input