### PR TITLE
Add/Subtract Sculpt direction Gizmo

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Select it and click `Install Add-on`.
 
 - `ADDED` : optional enable floating toggle for touch controls in mixed mode
 - `ADDED` : toggle touch controls button in node editor and image editor headers
+- `ADDED` : toggle sculpt direction gizmo
 
 </details>
 
@@ -215,7 +216,7 @@ Compatibility update for Blender 4.0
 
 </details>
 
-<details open><summary><b>v2.12.0</b></summary><br>
+<details><summary><b>v2.12.0</b></summary><br>
 
 - `UPDATED` : fixed bug with unindexed modes breaking gizmo menus
 - `UPDATED` : updated resize and change strength for 2D views
@@ -223,14 +224,14 @@ Compatibility update for Blender 4.0
 
 </details>
 
-<details open><summary><b>v2.11.0</b></summary><br>
+<details><summary><b>v2.11.0</b></summary><br>
 
 - `UPDATED` : added various GPENCIL modes to edit mode list
 - `UPDATED` : updated viewport gizmo panel to support v3.6 changes
 
 </details>
 
-<details open><summary><b>v2.10.0</b></summary><br>
+<details><summary><b>v2.10.0</b></summary><br>
 
 - `ADDED` : lazy camera control toggle in sculpt mode
 - `UPDATED` : add support for Weylus (\*nix) sending 0.0 for pressure on touch events
@@ -241,34 +242,34 @@ Compatibility update for Blender 4.0
 
 </details>
 
-<details open><summary><b>v2.9.0</b></summary><br>
+<details><summary><b>v2.9.0</b></summary><br>
 
 - `UPDATED` : additional changes to gizmo spacing
 - `UPDATED` : fixed bug preventing custom actions being assigned for radial menu
 
 </details>
 
-<details open><summary><b>v2.8.0</b></summary><br>
+<details><summary><b>v2.8.0</b></summary><br>
 
 - `UPDATED` : fixed issues with menu bar spacing
 - `REMOVED` : floating menu bar
 
 </details>
 
-<details open><summary><b>v2.7.1</b></summary><br>
+<details><summary><b>v2.7.1</b></summary><br>
 
 - `UPDATED` : replaced region_full_area with window_fullscreen
 
 </details>
 
-<details open><summary><b>v2.7.0</b></summary><br>
+<details><summary><b>v2.7.0</b></summary><br>
 
 - `ADDED` : relative remesh
 - `UPDATED` : fixed error when disabling add-on
 
 </details>
 
-<details open><summary><b>v2.6.0</b></summary><br>
+<details><summary><b>v2.6.0</b></summary><br>
 
 - `UPDATED` : code spec now based on flake8
 - `UPDATED` : added alternative action for TransferMode when used in OBJECT mode

--- a/Settings.py
+++ b/Settings.py
@@ -180,6 +180,7 @@ class OverlaySettings(AddonPreferences):
     show_multires: BoolProperty(name="Multires", default=True)
     show_voxel_remesh: BoolProperty(name="Voxel Remesh", default=True)
     show_brush_dynamics: BoolProperty(name="Brush Dynamics", default=True)
+    show_direction: BoolProperty(name="Brush Direction", default=True)
     gizmo_position: EnumProperty(
         items=position_items, name="Gizmo Position", default="RIGHT"
     )

--- a/__init__.py
+++ b/__init__.py
@@ -22,11 +22,10 @@ from .Settings import MenuModeGroup, OverlaySettings
 
 bl_info = {
     "name": "Touch Viewport",
-    "description":
-        "Creates active touch zones over View 2D and 3D areas for"
-        "easier viewport navigation with touch screens and pen tablets.",
+    "description": "Creates active touch zones over View 2D and 3D areas for"
+    "easier viewport navigation with touch screens and pen tablets.",
     "author": "NENDO",
-    "version": (4, 0, 3),
+    "version": (4, 0, 4),
     "blender": (2, 93, 0),
     "location": "View3D > Tools > NENDO",
     "warning": "",
@@ -37,15 +36,17 @@ bl_info = {
 
 
 has_run = False
+
+
 def register():
     bpy.utils.register_class(MenuModeGroup)
     bpy.utils.register_class(OverlaySettings)
-    bpy.context.preferences.addons[__package__.split('.')[0]].preferences.load() # type: ignore
+    bpy.context.preferences.addons[__package__.split(".")[0]].preferences.load()  # type: ignore
     lib.register()
 
 
 def unregister():
     lib.unregister()
-    bpy.context.preferences.addons[__package__.split('.')[0]].preferences.save() # type: ignore
+    bpy.context.preferences.addons[__package__.split(".")[0]].preferences.save()  # type: ignore
     bpy.utils.unregister_class(OverlaySettings)
     bpy.utils.unregister_class(MenuModeGroup)

--- a/lib/constants.py
+++ b/lib/constants.py
@@ -1,62 +1,86 @@
 # INPUT EVENTS
-TWEAK = 'TWEAK'
-MOUSE = 'MOUSE'
-PEN = 'PEN'
-MMOUSE = 'MIDDLEMOUSE'
-LMOUSE = 'LEFTMOUSE'
-RMOUSE = 'RIGHTMOUSE'
-PRESS = 'PRESS'
-DCLICK = 'DOUBLE_CLICK'
+TWEAK = "TWEAK"
+MOUSE = "MOUSE"
+PEN = "PEN"
+MMOUSE = "MIDDLEMOUSE"
+LMOUSE = "LEFTMOUSE"
+RMOUSE = "RIGHTMOUSE"
+PRESS = "PRESS"
+DCLICK = "DOUBLE_CLICK"
 
 # OPERATOR RESPONSES
-FINISHED = {'FINISHED'}
-MODAL = {'RUNNING_MODAL'}
-CANCEL = {'CANCELLED'}
-PASSTHROUGH = {'PASS_THROUGH'}
+FINISHED = {"FINISHED"}
+MODAL = {"RUNNING_MODAL"}
+CANCEL = {"CANCELLED"}
+PASSTHROUGH = {"PASS_THROUGH"}
 
 # DICTIONARIES
 flat_modes = ["Node Editor", "Image", "Image Paint", "UV Editor", "View2D"]
-top_level_names = ("Node Editor", "UV Editor", "Image Editor", "Image Paint",
-                   "3D View", "Image", "View2D", "Grease Pencil")
+top_level_names = (
+    "Node Editor",
+    "UV Editor",
+    "Image Editor",
+    "Image Paint",
+    "3D View",
+    "Image",
+    "View2D",
+    "Grease Pencil",
+)
 
-input_mode_items = [('ORBIT', 'rotate', 'Rotate the viewport'),
-                    ('PAN', 'pan', 'Move the viewport'),
-                    ('DOLLY', 'zoom', 'Zoom in/out the viewport')]
+input_mode_items = [
+    ("ORBIT", "rotate", "Rotate the viewport"),
+    ("PAN", "pan", "Move the viewport"),
+    ("DOLLY", "zoom", "Zoom in/out the viewport"),
+]
 
 position_items = [
-    ('TOP', 'top', 'Set Gizmo position to top of viewport'),
-    ('RIGHT', 'right', 'Set Gizmo position to right of viewport'),
-    ('BOTTOM', 'bottom', 'Set Gizmo position to bottom of viewport'),
-    ('LEFT', 'left', 'Set Gizmo position to left of viewport')
+    ("TOP", "top", "Set Gizmo position to top of viewport"),
+    ("RIGHT", "right", "Set Gizmo position to right of viewport"),
+    ("BOTTOM", "bottom", "Set Gizmo position to bottom of viewport"),
+    ("LEFT", "left", "Set Gizmo position to left of viewport"),
 ]
 
 pivot_items = [
-    ("SURFACE", "Surface",
-     "Sets the pivot position to the surface under the cursor."),
-    ("ACTIVE", "Active Vertex",
-     "Sets the pivot position to the active vertex position."),
-    ("UNMASKED", "Unmasked",
-     """
+    ("SURFACE", "Surface", "Sets the pivot position to the surface under the cursor."),
+    (
+        "ACTIVE",
+        "Active Vertex",
+        "Sets the pivot position to the active vertex position.",
+    ),
+    (
+        "UNMASKED",
+        "Unmasked",
+        """
         Sets the pivot position to the average position of the unmasked
         vertices.
-     """
-     ), ("ORIGIN", "Origin", "Sets the pivot to the origin of the sculpt."),
-    ("BORDER", "Mask Border",
-     "Sets the pivot position to the center of the border of the mask.")
+     """,
+    ),
+    ("ORIGIN", "Origin", "Sets the pivot to the origin of the sculpt."),
+    (
+        "BORDER",
+        "Mask Border",
+        "Sets the pivot position to the center of the border of the mask.",
+    ),
 ]
 
-pivot_icon_items = [("BORDER", "PIVOT_BOUNDBOX"), ("ORIGIN", "PIVOT_CURSOR"),
-                    ("UNMASKED", "CLIPUV_HLT"), ("ACTIVE", "PIVOT_ACTIVE"),
-                    ("SURFACE", "PIVOT_MEDIAN")]
+pivot_icon_items = [
+    ("BORDER", "PIVOT_BOUNDBOX"),
+    ("ORIGIN", "PIVOT_CURSOR"),
+    ("UNMASKED", "CLIPUV_HLT"),
+    ("ACTIVE", "PIVOT_ACTIVE"),
+    ("SURFACE", "PIVOT_MEDIAN"),
+]
 
-brush_modes = ['SCULPT','PAINT_VERTEX','PAINT_WEIGHT','PAINT_TEXTURE']
-edit_modes = [("OBJECT", "Object Mode", ""),
-              ("EDIT_MESH", "Edit Mode", ""),
-              ("SCULPT", "Sculpt Mode", ""),
-              ("PAINT_VERTEX", "Vertex Paint Mode", ""),
-              ("PAINT_WEIGHT", "Weight Paint Mode", ""),
-              ("PAINT_TEXTURE", "Texture Paint Mode", ""),
-              ("PAINT_GPENCIL", "2D Paint Mode", "")]
+brush_modes = ["SCULPT", "PAINT_VERTEX", "PAINT_WEIGHT", "PAINT_TEXTURE"]
+edit_modes = [
+    ("OBJECT", "Object Mode", ""),
+    ("EDIT_MESH", "Edit Mode", ""),
+    ("SCULPT", "Sculpt Mode", ""),
+    ("PAINT_VERTEX", "Vertex Paint Mode", ""),
+    ("PAINT_WEIGHT", "Weight Paint Mode", ""),
+    ("PAINT_TEXTURE", "Texture Paint Mode", ""),
+    ("PAINT_GPENCIL", "2D Paint Mode", ""),
+]
 
 menu_defaults = {
     "OBJECT": ("VIEW3D_MT_add", "object.shade_smooth", "", "", "", ""),
@@ -64,34 +88,50 @@ menu_defaults = {
     "SCULPT": ("object.quadriflow_remesh", "", "", "", "", ""),
     "PAINT_VERTEX": ("", "", "", "", "", ""),
     "PAINT_WEIGHT": ("", "", "", "", "", ""),
-    "PAINT_TEXTURE": ("", "", "", "", "", "")
+    "PAINT_TEXTURE": ("", "", "", "", "", ""),
 }
 
-double_click_items = [("object.transfer_mode", "Transfer Mode", ""),
-                      ("nendo.toggle_touch", "Toggle Touch View", ""),
-                      ("view3d.localview", "Toggle Local View", ""),
-                      ("wm.window_fullscreen_toggle", "Toggle Full Screen", "")]
+double_click_items = [
+    ("object.transfer_mode", "Transfer Mode", ""),
+    ("nendo.toggle_touch", "Toggle Touch View", ""),
+    ("view3d.localview", "Toggle Local View", ""),
+    ("wm.window_fullscreen_toggle", "Toggle Full Screen", ""),
+]
 
-menu_style_items = [("fixed.bar", "Fixed Bar", ""),
-                    ("float.radial", "Floating Radial", "")]
+menu_style_items = [
+    ("fixed.bar", "Fixed Bar", ""),
+    ("float.radial", "Floating Radial", ""),
+]
 
-menu_orientation_items = [("HORIZONTAL", "Horizontal", ""),
-                          ("VERTICAL", "Vertical", "")]
+menu_orientation_items = [
+    ("HORIZONTAL", "Horizontal", ""),
+    ("VERTICAL", "Vertical", ""),
+]
 
-control_gizmo_items = [("none", "", "disable_gizmo"),
-                       ("translate", "show_gizmo_object_translate", ""),
-                       ("rotate", "show_gizmo_object_rotate", ""),
-                       ("scale", "show_gizmo_object_scale", "")]
+control_gizmo_items = [
+    ("none", "", "disable_gizmo"),
+    ("translate", "show_gizmo_object_translate", ""),
+    ("rotate", "show_gizmo_object_rotate", ""),
+    ("scale", "show_gizmo_object_scale", ""),
+]
 
 gizmo_sets = {
     # ALL includes only the modes in this list
     "ALL": {
-        "undoredo", "show_fullscreen", "region_quadviews",
-        "snap_view", "n_panel", "lock_rotation"
+        "undoredo",
+        "show_fullscreen",
+        "region_quadviews",
+        "snap_view",
+        "n_panel",
+        "lock_rotation",
     },
     "SCULPT": {
-        "control_gizmo", "pivot_mode", "voxel_remesh", "multires",
-        "brush_dynamics"
+        "control_gizmo",
+        "pivot_mode",
+        "voxel_remesh",
+        "multires",
+        "brush_dynamics",
+        "direction",
     },
     "OBJECT": {"control_gizmo", "multires"},
     "EDIT_MESH": {"control_gizmo"},
@@ -104,5 +144,5 @@ gizmo_sets = {
     "VERTEX_GPENCIL": {"brush_dynamics"},
     "SCULPT_GPENCIL": {"brush_dynamics"},
     "PAINT_GPENCIL": {"brush_dynamics"},
-    "EDIT_GPENCIL": {"brush_dynamics"}
+    "EDIT_GPENCIL": {"brush_dynamics"},
 }

--- a/lib/operators/__init__.py
+++ b/lib/operators/__init__.py
@@ -25,16 +25,19 @@ __classes__ = (
     VIEW3D_OT_DecreaseMultires,
     VIEW3D_OT_DensityUp,
     VIEW3D_OT_DensityDown,
+    VIEW3D_OT_ToggleSculptAddSub,
 )
 
 
 def register():
     from bpy.utils import register_class
+
     for cls in __classes__:
         register_class(cls)
 
 
 def unregister():
     from bpy.utils import unregister_class
+
     for cls in reversed(__classes__):
         unregister_class(cls)

--- a/lib/operators/actions.py
+++ b/lib/operators/actions.py
@@ -8,30 +8,30 @@ from ..utils import get_settings
 
 
 class VIEW3D_OT_FlipTools(Operator):
-    """ Relocate Tools panel between left and right """
+    """Relocate Tools panel between left and right"""
+
     bl_idname = "view3d.tools_region_flip"
     bl_label = "Tools Region Swap"
 
     def execute(self, context: Context):
-        override: Context = context.copy() 
+        override: Context = context.copy()
         override["area"] = context.area
         override["region"] = context.region
         for r in context.area.regions:
-            if r.type == 'TOOLS':
+            if r.type == "TOOLS":
                 override["region"] = r
-        with context.temp_override(region=override["region"]): # type: ignore
+        with context.temp_override(region=override["region"]):  # type: ignore
             bpy.ops.screen.region_flip()
         return FINISHED
 
     @classmethod
     def poll(cls, context: Context):
-        return (
-            context.area.type == 'VIEW_3D' and context.region.type == 'WINDOW'
-        )
+        return context.area.type == "VIEW_3D" and context.region.type == "WINDOW"
 
 
 class VIEW3D_OT_NextPivotMode(Operator):
-    """ Step through Pivot modes """
+    """Step through Pivot modes"""
+
     bl_idname = "view3d.step_pivot_mode"
     bl_label = "Use next Pivot mode"
 
@@ -53,13 +53,12 @@ class VIEW3D_OT_NextPivotMode(Operator):
 
     @classmethod
     def poll(cls, context: Context):
-        return (
-            context.area.type == 'VIEW_3D' and context.region.type == 'WINDOW'
-        )
+        return context.area.type == "VIEW_3D" and context.region.type == "WINDOW"
 
 
 class VIEW3D_OT_ToggleTouchControls(Operator):
-    """ Toggle Touch Controls """
+    """Toggle Touch Controls"""
+
     bl_idname = "nendo.toggle_touch"
     bl_label = "Toggle Touch Controls"
 
@@ -71,7 +70,8 @@ class VIEW3D_OT_ToggleTouchControls(Operator):
 
 
 class VIEW3D_OT_ToggleNPanel(Operator):
-    """ Toggle Settings Panel """
+    """Toggle Settings Panel"""
+
     bl_idname = "nendo.toggle_n_panel"
     bl_label = "Display settings Panel"
 
@@ -83,13 +83,12 @@ class VIEW3D_OT_ToggleNPanel(Operator):
 
     @classmethod
     def poll(cls, context: Context):
-        return (
-            context.area.type == 'VIEW_3D' and context.region.type == 'WINDOW'
-        )
+        return context.area.type == "VIEW_3D" and context.region.type == "WINDOW"
 
 
 class VIEW3D_OT_ToggleFloatingMenu(Operator):
-    """ Toggle Floating Menu """
+    """Toggle Floating Menu"""
+
     bl_idname = "view3d.toggle_floating_menu"
     bl_label = "Toggle Floating Menu"
 
@@ -100,7 +99,8 @@ class VIEW3D_OT_ToggleFloatingMenu(Operator):
 
 
 class VIEW3D_OT_ViewportRecenter(Operator):
-    """ Recenter Viewport and Cursor on Selected Object """
+    """Recenter Viewport and Cursor on Selected Object"""
+
     bl_idname = "nendo.viewport_recenter"
     bl_label = "Recenter Viewport and Cursor on Selected"
 
@@ -115,7 +115,8 @@ class VIEW3D_OT_ViewportRecenter(Operator):
 
 
 class VIEW3D_OT_ViewportLock(Operator):
-    """ Toggle Viewport Rotation """
+    """Toggle Viewport Rotation"""
+
     bl_idname = "nendo.viewport_lock"
     bl_label = "Viewport rotation lock toggle"
 
@@ -147,14 +148,15 @@ class VIEW3D_OT_ViewportLock(Operator):
 
 
 class VIEW3D_OT_BrushResize(Operator):
-    """ Brush Resize """
+    """Brush Resize"""
+
     bl_idname = "nendo.brush_resize"
     bl_label = "Brush Size Adjust"
 
     # activate radial_control to change sculpt brush size
     def execute(self, context: Context):
         settings = get_settings()
-        if settings.menu_style in ['fixed.bar']:
+        if settings.menu_style in ["fixed.bar"]:
             if settings.gizmo_position in ["LEFT", "RIGHT"]:
                 context.window.cursor_warp(
                     math.floor(context.region.width / 2), self.mousey
@@ -163,41 +165,45 @@ class VIEW3D_OT_BrushResize(Operator):
                 context.window.cursor_warp(
                     self.mousex, math.floor(context.region.height / 2)
                 )
-        if context.mode in ['PAINT_GPENCIL', 'EDIT_GPENCIL','SCULPT_GPENCIL','WEIGHT_GPENCIL','VERTEX_GPENCIL']:
+        if context.mode in [
+            "PAINT_GPENCIL",
+            "EDIT_GPENCIL",
+            "SCULPT_GPENCIL",
+            "WEIGHT_GPENCIL",
+            "VERTEX_GPENCIL",
+        ]:
             return self.resize2d(context)
         return self.resize3d(context)
 
     def resize2d(self, context: Context):
         data_path = "tool_settings.gpencil_paint.brush.size"
-        if context.mode == 'SCULPT_GPENCIL':
+        if context.mode == "SCULPT_GPENCIL":
             data_path = "tool_settings.gpencil_sculpt_paint.brush.size"
-        if context.mode == 'WEIGHT_GPENCIL':
+        if context.mode == "WEIGHT_GPENCIL":
             data_path = "tool_settings.gpencil_weight_paint.brush.size"
-        if context.mode == 'VERTEX_GPENCIL':
+        if context.mode == "VERTEX_GPENCIL":
             data_path = "tool_settings.gpencil_vertex_paint.brush.size"
         bpy.ops.wm.radial_control(
-            'INVOKE_DEFAULT',  # type: ignore
+            "INVOKE_DEFAULT",  # type: ignore
             data_path_primary=data_path,
         )
         return FINISHED
 
     def resize3d(self, context: Context):
         data_path = "tool_settings.sculpt.brush.size"
-        if context.mode == 'PAINT_VERTEX':
+        if context.mode == "PAINT_VERTEX":
             data_path = "tool_settings.vertex_paint.brush.size"
-        if context.mode == 'PAINT_WEIGHT':
+        if context.mode == "PAINT_WEIGHT":
             data_path = "tool_settings.weight_paint.brush.size"
-        if context.mode == 'PAINT_IMAGE':
+        if context.mode == "PAINT_IMAGE":
             data_path = "tool_settings.image_paint.brush.size"
-        if context.mode == 'PAINT_TEXTURE':
+        if context.mode == "PAINT_TEXTURE":
             data_path = "tool_settings.image_paint.brush.size"
         bpy.ops.wm.radial_control(
-            'INVOKE_DEFAULT',  # type: ignore
+            "INVOKE_DEFAULT",  # type: ignore
             data_path_primary=data_path,
             data_path_secondary="tool_settings.unified_paint_settings.size",
-            use_secondary=(
-                "tool_settings.unified_paint_settings.use_unified_size"
-            ),
+            use_secondary=("tool_settings.unified_paint_settings.use_unified_size"),
             rotation_path="tool_settings.sculpt.brush.texture_slot.angle",
             color_path="tool_settings.sculpt.brush.cursor_color_add",
             image_id="tool_settings.sculpt.brush",
@@ -212,14 +218,15 @@ class VIEW3D_OT_BrushResize(Operator):
 
 
 class VIEW3D_OT_BrushStrength(Operator):
-    """ Brush Strength """
+    """Brush Strength"""
+
     bl_idname = "nendo.brush_strength"
     bl_label = "Brush Strength Adjust"
 
     # activate radial_control to change sculpt brush size
     def execute(self, context: Context):
         settings = get_settings()
-        if settings.menu_style in ['fixed.bar']:
+        if settings.menu_style in ["fixed.bar"]:
             if settings.gizmo_position in ["LEFT", "RIGHT"]:
                 context.window.cursor_warp(
                     math.floor(context.region.width / 2), self.mousey
@@ -228,43 +235,47 @@ class VIEW3D_OT_BrushStrength(Operator):
                 context.window.cursor_warp(
                     self.mousex, math.floor(context.region.height / 2)
                 )
-        if context.mode in ['PAINT_GPENCIL', 'EDIT_GPENCIL','SCULPT_GPENCIL','WEIGHT_GPENCIL','VERTEX_GPENCIL']:
+        if context.mode in [
+            "PAINT_GPENCIL",
+            "EDIT_GPENCIL",
+            "SCULPT_GPENCIL",
+            "WEIGHT_GPENCIL",
+            "VERTEX_GPENCIL",
+        ]:
             return self.resize2d(context)
         return self.resize3d(context)
 
     def resize2d(self, context: Context):
         data_path = "tool_settings.gpencil_paint.brush.gpencil_settings.pen_strength"
-        if context.mode == 'SCULPT_GPENCIL':
+        if context.mode == "SCULPT_GPENCIL":
             data_path = "tool_settings.gpencil_sculpt_paint.brush.strength"
-        if context.mode == 'WEIGHT_GPENCIL':
+        if context.mode == "WEIGHT_GPENCIL":
             data_path = "tool_settings.gpencil_weight_paint.brush.strength"
-        if context.mode == 'VERTEX_GPENCIL':
-            data_path = "tool_settings.gpencil_vertex_paint.brush.gpencil_settings.pen_strength"
+        if context.mode == "VERTEX_GPENCIL":
+            data_path = (
+                "tool_settings.gpencil_vertex_paint.brush.gpencil_settings.pen_strength"
+            )
         bpy.ops.wm.radial_control(
-            'INVOKE_DEFAULT',  # type: ignore
+            "INVOKE_DEFAULT",  # type: ignore
             data_path_primary=data_path,
         )
         return FINISHED
 
     def resize3d(self, context: Context):
         data_path = "tool_settings.sculpt.brush.strength"
-        if context.mode == 'PAINT_VERTEX':
+        if context.mode == "PAINT_VERTEX":
             data_path = "tool_settings.vertex_paint.brush.strength"
-        if context.mode == 'PAINT_WEIGHT':
+        if context.mode == "PAINT_WEIGHT":
             data_path = "tool_settings.weight_paint.brush.strength"
-        if context.mode == 'PAINT_IMAGE':
+        if context.mode == "PAINT_IMAGE":
             data_path = "tool_settings.image_paint.brush.strength"
-        if context.mode == 'PAINT_TEXTURE':
+        if context.mode == "PAINT_TEXTURE":
             data_path = "tool_settings.image_paint.brush.strength"
         bpy.ops.wm.radial_control(
-            'INVOKE_DEFAULT',  # type: ignore
+            "INVOKE_DEFAULT",  # type: ignore
             data_path_primary=data_path,
-            data_path_secondary=(
-                "tool_settings.unified_paint_settings.strength"
-            ),
-            use_secondary=(
-                "tool_settings.unified_paint_settings.use_unified_strength"
-            ),
+            data_path_secondary=("tool_settings.unified_paint_settings.strength"),
+            use_secondary=("tool_settings.unified_paint_settings.use_unified_strength"),
             rotation_path="tool_settings.sculpt.brush.texture_slot.angle",
             color_path="tool_settings.sculpt.brush.cursor_color_add",
             image_id="tool_settings.sculpt.brush",
@@ -279,34 +290,28 @@ class VIEW3D_OT_BrushStrength(Operator):
 
 
 class VIEW3D_OT_IncreaseMultires(Operator):
-    """ Increment Multires by 1 or add subdivision """
+    """Increment Multires by 1 or add subdivision"""
+
     bl_idname = "nendo.increment_multires"
     bl_label = "Increment Multires modifier by 1 or add subdivision level"
 
     def execute(self, context: Context):
         settings = get_settings()
-        if (
-            not context.active_object
-            or not len(context.active_object.modifiers)
-        ):
+        if not context.active_object or not len(context.active_object.modifiers):
             return CANCEL
         for mod in context.active_object.modifiers:
             # if mod is type of MultiresModifier
             if isinstance(mod, MultiresModifier):
-                if context.mode == 'SCULPT':
+                if context.mode == "SCULPT":
                     if mod.sculpt_levels == mod.total_levels:
                         if mod.sculpt_levels < settings.subdivision_limit:
-                            bpy.ops.object.multires_subdivide(
-                                modifier=mod.name
-                            )
+                            bpy.ops.object.multires_subdivide(modifier=mod.name)
                     else:
                         mod.sculpt_levels += 1
                 else:
                     if mod.levels == mod.total_levels:
                         if mod.levels < settings.subdivision_limit:
-                            bpy.ops.object.multires_subdivide(
-                                modifier=mod.name
-                            )
+                            bpy.ops.object.multires_subdivide(modifier=mod.name)
                     else:
                         mod.levels += 1
                 return FINISHED
@@ -314,20 +319,18 @@ class VIEW3D_OT_IncreaseMultires(Operator):
 
 
 class VIEW3D_OT_DecreaseMultires(Operator):
-    """ Decrement Multires by 1 """
+    """Decrement Multires by 1"""
+
     bl_idname = "nendo.decrement_multires"
     bl_label = "decrement Multires modifier by 1"
 
     def execute(self, context: Context):
-        if (
-            not context.active_object
-            or not len(context.active_object.modifiers)
-        ):
+        if not context.active_object or not len(context.active_object.modifiers):
             return CANCEL
         for mod in context.active_object.modifiers:
             if not isinstance(mod, MultiresModifier):
                 return FINISHED
-            if context.mode == 'SCULPT':
+            if context.mode == "SCULPT":
                 if mod.sculpt_levels == 0:
                     bpy.ops.object.multires_unsubdivide(modifier=mod.name)
                 else:
@@ -342,12 +345,13 @@ class VIEW3D_OT_DecreaseMultires(Operator):
 
 
 class VIEW3D_OT_DensityUp(Operator):
-    """ Increase voxel density """
+    """Increase voxel density"""
+
     bl_idname = "nendo.density_up"
     bl_label = "Increase voxel density and remesh"
 
     def execute(self, context: Context):
-        if (not context.active_object):
+        if not context.active_object:
             return CANCEL
         for mod in context.active_object.modifiers:
             if isinstance(mod, MultiresModifier):
@@ -359,12 +363,13 @@ class VIEW3D_OT_DensityUp(Operator):
 
 
 class VIEW3D_OT_DensityDown(Operator):
-    """ Decrease voxel density """
+    """Decrease voxel density"""
+
     bl_idname = "nendo.density_down"
     bl_label = "Decrease voxel density and remesh"
 
     def execute(self, context: Context):
-        if (not context.active_object):
+        if not context.active_object:
             return CANCEL
         for mod in context.active_object.modifiers:
             if isinstance(mod, MultiresModifier):
@@ -373,3 +378,22 @@ class VIEW3D_OT_DensityDown(Operator):
         mesh.remesh_voxel_size /= 0.8
         bpy.ops.object.voxel_remesh()
         return FINISHED
+
+
+class VIEW3D_OT_ToggleSculptAddSub(Operator):
+    """Toggle Sculpt Add/Sub"""
+
+    bl_idname = "nendo.toggle_sculpt_add_sub"
+    bl_label = "Toggle Sculpt Add/Sub"
+
+    def execute(self, context: Context):
+        context.tool_settings.sculpt.brush.direction = (
+            "ADD"
+            if context.tool_settings.sculpt.brush.direction == "SUBTRACT"
+            else "SUBTRACT"
+        )
+        return FINISHED
+
+    @classmethod
+    def poll(cls, context: Context):
+        return context.area.type == "VIEW_3D" and context.region.type == "WINDOW"

--- a/lib/ui_gizmo/gizmo_config.py
+++ b/lib/ui_gizmo/gizmo_config.py
@@ -12,57 +12,42 @@ from ..constants import pivot_icon_items
 # Simple 2D Gizmo
 controllerConfig = {
     "type": "default",
-    "binding": {
-        "location": "",
-        "name": "menu_controller"
-    },
+    "binding": {"location": "", "name": "menu_controller"},
     "command": "nendo.move_float_menu",
     "icon": "BLANK1",
-    "use_grab_cursor": True
+    "use_grab_cursor": True,
 }
 
 floatingConfig = {
     "type": "default",
-    "binding": {
-        "location": "prefs",
-        "name": "float_menu"
-    },
+    "binding": {"location": "prefs", "name": "float_menu"},
     "command": "nendo.move_action_menu",
     "icon": "SETTINGS",
-    "use_grab_cursor": True
+    "use_grab_cursor": True,
 }
 
 floatingToggleConfig = {
     "type": "boolean",
-    "binding": {
-        "location": "",
-        "name": "float_toggle"
-    },
+    "binding": {"location": "", "name": "float_toggle"},
     "command": "nendo.move_toggle_button",
     "onIcon": "OUTLINER_DATA_CAMERA",
     "offIcon": "GREASEPENCIL",
-    "use_grab_cursor": True
+    "use_grab_cursor": True,
 }
 
 undoConfig = {
     "type": "default",
-    "binding": {
-        "location": "prefs",
-        "name": "undoredo"
-    },
+    "binding": {"location": "prefs", "name": "undoredo"},
     "has_dependent": True,
     "command": "ed.undo",
-    "icon": "LOOP_BACK"
+    "icon": "LOOP_BACK",
 }
 
 redoConfig = {
     "type": "default",
-    "binding": {
-        "location": "prefs",
-        "name": "undoredo"
-    },
+    "binding": {"location": "prefs", "name": "undoredo"},
     "command": "ed.redo",
-    "icon": "LOOP_FORWARDS"
+    "icon": "LOOP_FORWARDS",
 }
 
 touchViewConfig = {
@@ -72,7 +57,7 @@ touchViewConfig = {
         "name": "is_enabled",
     },
     "command": "nendo.toggle_touch",
-    "icon": "VIEW_PAN"
+    "icon": "VIEW_PAN",
 }
 
 controlGizmoConfig = {
@@ -82,27 +67,21 @@ controlGizmoConfig = {
         "name": "control_gizmo",
     },
     "command": "nendo.cycle_control_gizmo",
-    "icon": "ORIENTATION_LOCAL"
+    "icon": "ORIENTATION_LOCAL",
 }
 
 snapViewConfig = {
     "type": "default",
-    "binding": {
-        "location": "prefs",
-        "name": "snap_view"
-    },
+    "binding": {"location": "prefs", "name": "snap_view"},
     "command": "nendo.viewport_recenter",
-    "icon": "CURSOR"
+    "icon": "CURSOR",
 }
 
 nPanelConfig = {
     "type": "default",
-    "binding": {
-        "location": "prefs",
-        "name": "n_panel"
-    },
+    "binding": {"location": "prefs", "name": "n_panel"},
     "command": "nendo.toggle_n_panel",
-    "icon": "EVENT_N"
+    "icon": "EVENT_N",
 }
 
 voxelSizeConfig = {
@@ -113,11 +92,11 @@ voxelSizeConfig = {
         "attribute": {
             "path": "active_object.modifiers.type",
             "value": "MULTIRES",
-            "state": False
-        }
+            "state": False,
+        },
     },
     "command": "object.voxel_size_edit",
-    "icon": "MESH_GRID"
+    "icon": "MESH_GRID",
 }
 
 voxelRemeshConfig = {
@@ -128,11 +107,11 @@ voxelRemeshConfig = {
         "attribute": {
             "path": "active_object.modifiers.type",
             "value": "MULTIRES",
-            "state": False
-        }
+            "state": False,
+        },
     },
     "command": "object.voxel_remesh",
-    "icon": "MOD_UVPROJECT"
+    "icon": "MOD_UVPROJECT",
 }
 
 voxelStepDownConfig = {
@@ -143,11 +122,11 @@ voxelStepDownConfig = {
         "attribute": {
             "path": "active_object.modifiers.type",
             "value": "MULTIRES",
-            "state": False
-        }
+            "state": False,
+        },
     },
     "command": "nendo.density_down",
-    "icon": "TRIA_DOWN"
+    "icon": "TRIA_DOWN",
 }
 
 voxelStepUpConfig = {
@@ -158,11 +137,11 @@ voxelStepUpConfig = {
         "attribute": {
             "path": "active_object.modifiers.type",
             "value": "MULTIRES",
-            "state": False
-        }
+            "state": False,
+        },
     },
     "command": "nendo.density_up",
-    "icon": "TRIA_UP"
+    "icon": "TRIA_UP",
 }
 
 subdivConfig = {
@@ -173,12 +152,12 @@ subdivConfig = {
         "attribute": {
             "path": "active_object.modifiers.type",
             "value": "MULTIRES",
-            "state": True
-        }
+            "state": True,
+        },
     },
     "has_dependent": True,
     "command": "nendo.increment_multires",
-    "icon": "TRIA_UP"
+    "icon": "TRIA_UP",
 }
 
 unsubdivConfig = {
@@ -189,31 +168,25 @@ unsubdivConfig = {
         "attribute": {
             "path": "active_object.modifiers.type",
             "value": "MULTIRES",
-            "state": True
-        }
+            "state": True,
+        },
     },
     "command": "nendo.decrement_multires",
-    "icon": "TRIA_DOWN"
+    "icon": "TRIA_DOWN",
 }
 
 brushResizeConfig = {
     "type": "default",
-    "binding": {
-        "location": "prefs",
-        "name": "brush_dynamics"
-    },
+    "binding": {"location": "prefs", "name": "brush_dynamics"},
     "command": "nendo.brush_resize",
-    "icon": "ANTIALIASED"
+    "icon": "ANTIALIASED",
 }
 
 brushStrengthConfig = {
     "type": "default",
-    "binding": {
-        "location": "prefs",
-        "name": "brush_dynamics"
-    },
+    "binding": {"location": "prefs", "name": "brush_dynamics"},
     "command": "nendo.brush_strength",
-    "icon": "SMOOTHCURVE"
+    "icon": "SMOOTHCURVE",
 }
 
 # Boolean 2D Gizmo
@@ -221,33 +194,44 @@ fullscreenToggleConfig = {
     "type": "boolean",
     "binding": {
         "location": "screen",
-        "name": "show_fullscreen"
+        "name": "show_fullscreen",
     },  # property location, watch-boolean
     "command": "screen.screen_full_area",
     "onIcon": "FULLSCREEN_EXIT",  # on-state
-    "offIcon": "FULLSCREEN_ENTER"  # off-state
+    "offIcon": "FULLSCREEN_ENTER",  # off-state
 }
 
 quadviewToggleConfig = {
     "type": "boolean",
-    "binding": {
-        "location": "space_data",
-        "name": "region_quadviews"
-    },
+    "binding": {"location": "space_data", "name": "region_quadviews"},
     "command": "screen.region_quadview",
     "onIcon": "IMGDISPLAY",
-    "offIcon": "MESH_PLANE"
+    "offIcon": "MESH_PLANE",
 }
 
 rotLocToggleConfig = {
     "type": "boolean",
-    "binding": {
-        "location": "region_data",
-        "name": "lock_rotation"
-    },
+    "binding": {"location": "region_data", "name": "lock_rotation"},
     "command": "nendo.viewport_lock",
     "onIcon": "LOCKED",
-    "offIcon": "UNLOCKED"
+    "offIcon": "UNLOCKED",
+}
+
+addSubtractToggleConfig = {
+    "type": "boolean",
+    "binding": {
+        "location": "tool_settings",
+        "name": "direction",
+        "attribute": {
+            "path": "tool_settings.sculpt.brush",
+            "value": "direction",
+            "state": "ADD",
+            "mode": "enum",
+        },
+    },
+    "command": "nendo.toggle_sculpt_add_sub",
+    "onIcon": "ADD",
+    "offIcon": "REMOVE",
 }
 
 gizmo_colors = {
@@ -255,26 +239,26 @@ gizmo_colors = {
         "color": [0.0, 0.0, 0.0],
         "color_highlight": [0.0, 0.0, 0.0],
         "alpha": 0.3,
-        "alpha_highlight": 0.3
+        "alpha_highlight": 0.3,
     },
     "active": {
         "color": [0.0, 0.0, 0.0],
         "alpha": 0.5,
         "color_highlight": [0.5, 0.5, 0.5],
-        "alpha_highlight": 0.5
+        "alpha_highlight": 0.5,
     },
     "error": {
         "color": [0.3, 0.0, 0.0],
         "alpha": 0.15,
         "color_highlight": [1.0, 0.2, 0.2],
-        "alpha_highlight": 0.5
+        "alpha_highlight": 0.5,
     },
     "warn": {
         "color": [0.35, 0.3, 0.14],
         "alpha": 0.15,
         "color_highlight": [0.8, 0.7, 0.3],
-        "alpha_highlight": 0.3
-    }
+        "alpha_highlight": 0.3,
+    },
 }
 
 toggle_colors = {
@@ -282,14 +266,14 @@ toggle_colors = {
         "color": [0.1, 0.1, 0.2],
         "alpha": 0.5,
         "color_highlight": [0.15, 0.15, 0.3],
-        "alpha_highlight": 0.7
+        "alpha_highlight": 0.7,
     },
     "inactive": {
         "color": [0.0, 0.0, 0.0],
         "alpha": 0.5,
         "color_highlight": [0.05, 0.05, 0.05],
-        "alpha_highlight": 0.7
-    }
+        "alpha_highlight": 0.7,
+    },
 }
 
 # Enum 2D Gizmo
@@ -297,10 +281,7 @@ toggle_colors = {
 # not implemented yet
 pivotModeConfig = {
     "type": "enum",
-    "binding": {
-        "location": "prefs",
-        "name": "pivot_mode"
-    },
+    "binding": {"location": "prefs", "name": "pivot_mode"},
     "command": "",
-    "icons": pivot_icon_items
+    "icons": pivot_icon_items,
 }

--- a/lib/ui_gizmo/gizmo_group_2d.py
+++ b/lib/ui_gizmo/gizmo_group_2d.py
@@ -7,15 +7,28 @@ from ..utils import buildSafeArea, dpi_factor, get_settings
 from .gizmo_2d import GizmoSet, GizmoSetBoolean
 from .gizmo_config import *
 
-__module__ = __name__.split('.')[0]
+__module__ = __name__.split(".")[0]
 
 
 configs = [
-    undoConfig, redoConfig, touchViewConfig, controlGizmoConfig,
-    snapViewConfig, fullscreenToggleConfig, quadviewToggleConfig,
-    rotLocToggleConfig, nPanelConfig, voxelSizeConfig, voxelRemeshConfig,
-    voxelStepDownConfig, voxelStepUpConfig,
-    subdivConfig, unsubdivConfig, brushResizeConfig, brushStrengthConfig
+    undoConfig,
+    redoConfig,
+    touchViewConfig,
+    controlGizmoConfig,
+    snapViewConfig,
+    fullscreenToggleConfig,
+    quadviewToggleConfig,
+    rotLocToggleConfig,
+    nPanelConfig,
+    voxelSizeConfig,
+    voxelRemeshConfig,
+    voxelStepDownConfig,
+    voxelStepUpConfig,
+    addSubtractToggleConfig,
+    subdivConfig,
+    unsubdivConfig,
+    brushResizeConfig,
+    brushStrengthConfig,
 ]
 
 ###
@@ -41,9 +54,9 @@ configs = [
 class GIZMO_GT_ViewportGizmoGroup(GizmoGroup):
     bl_idname = "GIZMO_GT_touch_tools"
     bl_label = "Fast access tools for touch viewport"
-    bl_space_type = 'VIEW_3D'
-    bl_region_type = 'WINDOW'
-    bl_options = {'PERSISTENT', 'SCALE'}
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "WINDOW"
+    bl_options = {"PERSISTENT", "SCALE"}
 
     # set up gizmo collection
     def setup(self, context: Context):
@@ -52,7 +65,7 @@ class GIZMO_GT_ViewportGizmoGroup(GizmoGroup):
         settings = get_settings()
         self.spacing = settings.menu_spacing
         for conf in configs:
-            if conf['type'] == "boolean":
+            if conf["type"] == "boolean":
                 gizmo = GizmoSetBoolean()
                 gizmo.setup(self, conf)
             else:  # assume Type = Default
@@ -87,9 +100,9 @@ class GIZMO_GT_ViewportGizmoGroup(GizmoGroup):
             if gizmo.visible:
                 visible_gizmos.append(gizmo)
 
-        if settings.menu_style == 'float.radial':
+        if settings.menu_style == "float.radial":
             self.__menuRadial(visible_gizmos)
-        if settings.menu_style == 'fixed.bar':
+        if settings.menu_style == "fixed.bar":
             self.__menuBar(visible_gizmos)
 
     def __menuBar(self, visible_gizmos: list[GizmoSet]):
@@ -98,38 +111,49 @@ class GIZMO_GT_ViewportGizmoGroup(GizmoGroup):
         scalar = 22 * dpi_factor()
         count = len(visible_gizmos)
         safe_area = buildSafeArea()
-        origin = Vector(((safe_area[0].x + safe_area[1].x) / 2,
-                            (safe_area[0].y + safe_area[1].y) / 2, 0.0))
+        origin = Vector(
+            (
+                (safe_area[0].x + safe_area[1].x) / 2,
+                (safe_area[0].y + safe_area[1].y) / 2,
+                0.0,
+            )
+        )
 
-        if settings.gizmo_position == 'TOP':
+        if settings.gizmo_position == "TOP":
             origin.y = safe_area[1].y
-        elif settings.gizmo_position == 'BOTTOM':
+        elif settings.gizmo_position == "BOTTOM":
             origin.y = safe_area[0].y
         else:
-            if settings.gizmo_position == 'LEFT':
+            if settings.gizmo_position == "LEFT":
                 origin.x = safe_area[0].x
-            elif settings.gizmo_position == 'RIGHT':
+            elif settings.gizmo_position == "RIGHT":
                 origin.x = safe_area[1].x
 
-        gizmo_spacing = (settings.menu_spacing + scalar)
-        if ((settings.gizmo_position in ['TOP', 'BOTTOM']
-            and settings.menu_style == 'fixed.bar')):
+        gizmo_spacing = settings.menu_spacing + scalar
+        if (
+            settings.gizmo_position in ["TOP", "BOTTOM"]
+            and settings.menu_style == "fixed.bar"
+        ):
             start = origin.x - ((count - 1) * gizmo_spacing) / 2
             for i, gizmo in enumerate(visible_gizmos):
                 self.__move_gizmo(
-                    gizmo, Vector((start + (i * gizmo_spacing), origin.y, 0.0)))
+                    gizmo, Vector((start + (i * gizmo_spacing), origin.y, 0.0))
+                )
         else:
             start = origin.y + (count * gizmo_spacing) / 2
             for i, gizmo in enumerate(visible_gizmos):
                 self.__move_gizmo(
-                    gizmo, Vector((origin.x, start - (i * gizmo_spacing), 0.0)))
+                    gizmo, Vector((origin.x, start - (i * gizmo_spacing), 0.0))
+                )
 
     def __menuRadial(self, visible_gizmos: list[GizmoSet]):
         settings = get_settings()
         # calculate minimum radius to prevent overlapping buttons
         gui_scale = dpi_factor() * 3
-        radial_size = (gui_scale + settings.menu_spacing)
-        spacing = radial_size + (gui_scale * settings.gizmo_scale) + settings.gizmo_padding
+        radial_size = gui_scale + settings.menu_spacing
+        spacing = (
+            radial_size + (gui_scale * settings.gizmo_scale) + settings.gizmo_padding
+        )
 
         count = len(visible_gizmos)
         # reposition Gizmos to origin
@@ -144,11 +168,11 @@ class GIZMO_GT_ViewportGizmoGroup(GizmoGroup):
             else:
                 self.__calcMove(gizmo, i, count, spacing)
 
-    def __calcMove(self, gizmo: GizmoSet, step: int, size: int,
-                   spacing: float):
+    def __calcMove(self, gizmo: GizmoSet, step: int, size: int, spacing: float):
         distance = step / size
         offset = Vector(
-            (sin(radians(distance * 360)), cos(radians(distance * 360)), 0.0))
+            (sin(radians(distance * 360)), cos(radians(distance * 360)), 0.0)
+        )
         self.__move_gizmo(gizmo, self.origin + offset * spacing)
 
     def __updateOrigin(self):
@@ -157,12 +181,17 @@ class GIZMO_GT_ViewportGizmoGroup(GizmoGroup):
 
         # distance across viewport between menus
         span = Vector(
-            (safe_area[1].x - safe_area[0].x, safe_area[1].y - safe_area[0].y))
+            (safe_area[1].x - safe_area[0].x, safe_area[1].y - safe_area[0].y)
+        )
 
         # apply position ratio to safe area
         self.origin = Vector(
-            (safe_area[0].x + span.x * settings.menu_position[0] * 0.01,
-             safe_area[0].y + span.y * settings.menu_position[1] * 0.01, 0.0))
+            (
+                safe_area[0].x + span.x * settings.menu_position[0] * 0.01,
+                safe_area[0].y + span.y * settings.menu_position[1] * 0.01,
+                0.0,
+            )
+        )
 
     def __updateActionOrigin(self):
         safe_area = buildSafeArea()
@@ -170,13 +199,17 @@ class GIZMO_GT_ViewportGizmoGroup(GizmoGroup):
 
         # distance across viewport between menus
         span = Vector(
-            (safe_area[1].x - safe_area[0].x, safe_area[1].y - safe_area[0].y))
+            (safe_area[1].x - safe_area[0].x, safe_area[1].y - safe_area[0].y)
+        )
 
         # apply position ratio to safe area
         self.action_origin = Vector(
-            (safe_area[0].x + span.x * settings.floating_position[0] * 0.01,
-             safe_area[0].y + span.y * settings.floating_position[1] * 0.01,
-             0.0))
+            (
+                safe_area[0].x + span.x * settings.floating_position[0] * 0.01,
+                safe_area[0].y + span.y * settings.floating_position[1] * 0.01,
+                0.0,
+            )
+        )
 
     def __updateToggleOrigin(self):
         safe_area = buildSafeArea()
@@ -184,13 +217,17 @@ class GIZMO_GT_ViewportGizmoGroup(GizmoGroup):
 
         # distance across viewport between menus
         span = Vector(
-            (safe_area[1].x - safe_area[0].x, safe_area[1].y - safe_area[0].y))
+            (safe_area[1].x - safe_area[0].x, safe_area[1].y - safe_area[0].y)
+        )
 
         # apply position ratio to safe area
         self.toggle_origin = Vector(
-            (safe_area[0].x + span.x * settings.toggle_position[0] * 0.01,
-             safe_area[0].y + span.y * settings.toggle_position[1] * 0.01,
-             0.0))
+            (
+                safe_area[0].x + span.x * settings.toggle_position[0] * 0.01,
+                safe_area[0].y + span.y * settings.toggle_position[1] * 0.01,
+                0.0,
+            )
+        )
 
     def __move_gizmo(self, gizmo: GizmoSet, position: Vector):
         gizmo.move(position)


### PR DESCRIPTION
Adds new Gizmo for toggling between +/- sculpt brush direction. Due to how Blender implemented Brushes, it's difficult to support brushes that do not explicitly use `('ADD', 'SUBTRACT')` for `brush.direction`. In those cases, the gizmo is hidden.

resolves #36 